### PR TITLE
Update install.sh and add Packer template for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	packer build build/templates/ubuntu.json

--- a/build/templates/ubuntu.json
+++ b/build/templates/ubuntu.json
@@ -1,0 +1,30 @@
+{
+    "variables": {
+        "api_token": "{{ env `DIGITALOCEAN_ACCESS_TOKEN` }}",
+        "the_hunting_dir": "{{ env `PWD` }}"
+    },
+    "builders": [
+        {
+            "type": "digitalocean",
+            "snapshot_name": "the_hunting-{{ timestamp }}",
+            "api_token": "{{ user `api_token` }}",
+            "image": "ubuntu-20-04-x64",
+            "region": "sfo2",
+            "size": "s-1vcpu-1gb",
+            "ssh_username": "root"
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "file",
+            "source": "{{ user `the_hunting_dir` }}",
+            "destination": "/the_hunting"
+        },
+        {
+            "type": "shell",
+            "inline": [
+                "/bin/bash /the_hunting/install.sh --install"
+            ]
+        }
+    ]
+}

--- a/docs/building-do-image.md
+++ b/docs/building-do-image.md
@@ -1,0 +1,41 @@
+# Building Digital Ocean Image
+
+There is a [Packer](https:/github.com/hashicorp/packer) template available that will build a DigitalOcean image and store it as `the_thunting-{{timestamp}}`. This can be used for development and testing.
+
+## Setup Environment
+
+The only requirement is that `$DIGITALOCEAN_ACCESS_TOKEN` is properly set in the environment. If you have `yq` installed it is quite simple.
+
+MacOS
+
+```bash
+export DIGITALOCEAN_ACCESS_TOKEN="$(yq r "${HOME}/Library/Application Support/doctl/config.yaml" access-token)
+```
+
+Linux
+
+```bash
+export DIGITALOCEAN_ACCESS_TOKEN="$(yq r "${HOME}/.config/doctl/config.yaml" access-token)
+```
+
+or you can use `awk`
+
+MacOS
+
+```bash
+export DIGITALOCEAN_ACCESS_TOKEN="$(awk '/access-token/ {print $2}' "${HOME}/Library/Application Support/doctl/config.yaml")"
+```
+
+Linux
+
+```bash
+export DIGITALOCEAN_ACCESS_TOKEN="$(awk '/access-token/ {print $2}' "${HOME}/Library/Application Support/doctl/config.yaml")"
+```
+
+## Building Image
+
+Simply run the `build` make target.
+
+```bash
+make build
+```

--- a/install.sh
+++ b/install.sh
@@ -1,69 +1,34 @@
 #!/bin/bash -
 #Shouldnt need to be ran in axiom droplet
 #this is for install and use on ubuntu 20.04 for testing
-usage() { logo; echo -e "Usage: ./install.sh -[i]\nOptions:\n  -i\t-\tinstall everything\n  -u\t-\tupdate everything\n  -p\t-\tinstall pre_reqs\n  -t\t-\tinstall tools\n  -w\t-\tupdate wordlists\n  -a\t-\tupdate all tools\n  -l\t-\tless LICENSE\n" 1>&2; exit 1; }
-# niiiiice @1efty
-while [[ $1 ]]; do
-	echo "Handling [$1]..."
-	case "$1" in
-    --install)
-        install
-        ;;
-    --update_hunting)
-			  update_the_hunting
-		  	;;
-    --pre_reqs)
-        pre_reqs
-	  		;;
-    --install_tools)
-        install_tools
-  			;;
-    --update_wordlists)
-        update_wordlists
-	  		;;
-    --update_all)
-        update_all_tools
-	  		;;
-    --license)
-        less ./LICENSE
-        exit 1
-	  		;;
-    *)
-        echo "Error: Unknown option: $1" >&2
-	  		exit 1
-	  		;;
-	esac
-done
+usage() {
+  echo -e "Usage: ./install.sh -[i]\nOptions:\n  -i\t-\tinstall everything\n  -u\t-\tupdate everything\n  -p\t-\tinstall pre_reqs\n  -t\t-\tinstall tools\n  -w\t-\tupdate wordlists\n  -a\t-\tupdate all tools\n  -l\t-\tless LICENSE\n" 1>&2
+  exit 1
+}
 
-#shift $((OPTIND - 1))
-
-update_all_tools(){
-# Probably need to add some uname checks and then set up package repo.
+function update_all_tools() {
+  # Probably need to add some uname checks and then set up package repo.
   apt update && apt upgrade -y
   snap refresh
 }
-update_the_hunting(){
+
+function update_the_hunting() {
   git pull
 }
-#prereqs
-pre_reqs(){
-  snap install chromium
-  apt install parallel -y
-  go_lang
-}
 
-go_lang(){
-  wget https://golang.org/dl/go1.15.linux-amd64.tar.gz
-  sudo tar -C /usr/local -xzf go1.15.linux-amd64.tar.gz
-  echo "export PATH=$PATH:/usr/local/go/bin" >> $HOME/.bashrc
-  source $HOME/.bashrc
+#prereqs
+function pre_reqs() {
+  apt update && apt upgrade -y
+  apt install snapd sudo wget git make unzip parallel golang -y
+  snap install chromium
 }
 
 # tool install
-install_amass(){
+function install_amass() {
   snap install amass
 }
-install_gobuster(){
+
+function install_gobuster() {
   git clone https://github.com/OJ/gobuster
   cd ./gobuster/
   go get && go build
@@ -71,31 +36,37 @@ install_gobuster(){
   cd ./build/gobuster-linux-amd64
   sudo cp gobuster /usr/bin/gobuster
 }
-install_subjack(){
+
+function install_subjack() {
   go get github.com/haccer/subjack
-  echo 'alias subjack="~/go/bin/subjack"' >> $HOME/.bashrc
+  echo 'alias subjack="~/go/bin/subjack"' >>$HOME/.bashrc
 }
-install_httprobe(){
+
+function install_httprobe() {
   go get -u github.com/tomnomnom/httprobe
   alias httprobe="~/go/bin/httprobe"
 }
-install_aquatone(){
+
+function install_aquatone() {
   wget https://github.com/michenriksen/aquatone/releases/download/v1.7.0/aquatone_linux_amd64_1.7.0.zip
   unzip aquatone_linux_amd64_1.7.0.zip
   mv aquatone /usr/local/bin/aquatone
 }
-install_nuclei(){
+
+function install_nuclei() {
   git clone https://github.com/projectdiscovery/nuclei.git
   cd nuclei/cmd/nuclei/
   go build .
   mv nuclei /usr/local/bin/
   cd ../../../
 }
-install_chromium(){
+
+function install_chromium() {
   # Probably need to add some uname checks and then set up package repo.
   type -P chromium &>/dev/null || sudo snap install chromium
 }
-install_tools(){
+
+function install_tools() {
   cd ./temp
   install_amass
   install_gobuster
@@ -107,8 +78,54 @@ install_tools(){
   cd ..
 }
 
-install(){
-  update_all_tools
+function install_all() {
   pre_reqs
   install_tools
 }
+
+function parse_args() {
+  # niiiiice @1efty
+  while [[ $1 ]]; do
+    echo "Handling [$1]..."
+    case "$1" in
+    --install)
+      install_all
+      shift
+      ;;
+    --update_hunting)
+      update_the_hunting
+      shift
+      ;;
+    --pre_reqs)
+      pre_reqs
+      shift
+      ;;
+    --install_tools)
+      install_tools
+      shift
+      ;;
+    --update_wordlists)
+      update_wordlists
+      shift
+      ;;
+    --update_all)
+      update_all_tools
+      shift
+      ;;
+    --license)
+      less ./LICENSE
+      exit 1
+      ;;
+    *)
+      echo "Error: Unknown option: $1" >&2
+      exit 1
+      ;;
+    esac
+  done
+}
+
+function main() {
+  parse_args $@
+}
+
+main $@


### PR DESCRIPTION
This does the following:
- Adds a Packer template for easily testing `install.sh`. I tried to build a container based test, but snapd is the devil and doesn't play well within a container...
- Adds a makefile to easily build an image
- Documentation on how to build image for digital ocean using packer
- Fixes up `install.sh`
- Opts for the ubuntu `golang` package instead of installing from source (more reliable installation method but does drop the version down to 1.13)